### PR TITLE
build: pin go toolchain to latest patch version for security

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-icmp
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require (
 	github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b
 	github.com/mstoykov/k6-taskqueue-lib v0.1.3


### PR DESCRIPTION
Pin the Go toolchain in go.mod to the latest patch version of the minor it currently targets, picking up the latest security and bugfix releases.